### PR TITLE
changed args handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jessfraz/udict/api"
 	"github.com/jessfraz/udict/version"
@@ -49,7 +50,7 @@ func init() {
 	}
 
 	// parse the arg
-	arg := flag.Args()[0]
+	arg := strings.Join(flag.Args(), " ")
 
 	if arg == "help" {
 		usageAndExit("", 0)
@@ -62,7 +63,7 @@ func init() {
 }
 
 func main() {
-	word := flag.Args()[0]
+	word := strings.Join(flag.Args(), " ")
 
 	response, err := api.Define(word)
 	if err != nil {


### PR DESCRIPTION
- multiple arguments are now joined into one search term, that way quotes are not needed around multiple arguments.

Previously, if you searched for "bless your heart", the results returned were for the first word, "bless". Ex - this searched for "bless":

```
$ udict bless your heart
```

Meanwhile, if you searched properly, quoting multiple words so they were passed as one argument from bash to the script, it searched for all of the words you gave - which seems more natural. Ex:

```
$ udict "bless your heart"
```

The change really just joins all arguments together with spaces, and searches for that - so the two work mostly the same.

Do note, I don't know whether to classify this as a feature or a bugfix, so I did not bump the version number.